### PR TITLE
fixed missing Jason.pch for XCode 5

### DIFF
--- a/Jason.xcodeproj/project.pbxproj
+++ b/Jason.xcodeproj/project.pbxproj
@@ -50,7 +50,6 @@
 
 /* Begin PBXFileReference section */
 		089C1660FE840EACC02AAC07 /* English */ = {isa = PBXFileReference; fileEncoding = 10; lastKnownFileType = text.plist.strings; name = English; path = English.lproj/InfoPlist.strings; sourceTree = "<group>"; };
-		0A4183721938322900FB18D6 /* Jason.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Jason.pch; path = Support/Jason.pch; sourceTree = "<group>"; };
 		1058C7A7FEA54F5311CA2CBB /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = /System/Library/Frameworks/Cocoa.framework; sourceTree = "<absolute>"; };
 		1418D024125D61D10040CBB6 /* DocumentWC.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DocumentWC.h; path = Document/DocumentWC.h; sourceTree = "<group>"; };
 		1418D025125D61D10040CBB6 /* DocumentWC.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = DocumentWC.m; path = Document/DocumentWC.m; sourceTree = "<group>"; };
@@ -231,7 +230,6 @@
 			isa = PBXGroup;
 			children = (
 				14E795D2125BBAAC006EC2F6 /* main.m */,
-				0A4183721938322900FB18D6 /* Jason.pch */,
 			);
 			name = "Other Sources";
 			sourceTree = "<group>";
@@ -444,7 +442,6 @@
 				GCC_MODEL_TUNING = G5;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PRECOMPILE_PREFIX_HEADER = NO;
-				GCC_PREFIX_HEADER = Support/Jason.pch;
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "$(HOME)/Applications";
 				PRODUCT_NAME = Jason;
@@ -467,7 +464,6 @@
 				GCC_ENABLE_OBJC_GC = unsupported;
 				GCC_MODEL_TUNING = G5;
 				GCC_PRECOMPILE_PREFIX_HEADER = NO;
-				GCC_PREFIX_HEADER = Support/Jason.pch;
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "$(HOME)/Applications";
 				PRODUCT_NAME = Jason;


### PR DESCRIPTION
The Jason.pch file is missing (at least for XCode 5). Removing it from the project seems to fix the problem.

Tested on OSX 10.9
